### PR TITLE
feat: implement TODOs & fix tests

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/factories.py
+++ b/cms/djangoapps/modulestore_migrator/tests/factories.py
@@ -15,7 +15,6 @@ class ModulestoreSourceFactory(factory.django.DjangoModelFactory):
     """
     class Meta:
         model = ModulestoreSource
-    forwarded_by = None
 
     @factory.lazy_attribute
     def key(self):

--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -84,7 +84,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
 
         result = _slugify_source_usage_key(usage_key)
 
-        self.assertEqual(result, "TestOrg__TestCourse__TestRun__test_problem")
+        self.assertEqual(result, "TestOrg__TestCourse__TestRun__test_problem_9a9c0b4c")
 
     def test_slugify_source_usage_key_library(self):
         """
@@ -95,7 +95,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
 
         result = _slugify_source_usage_key(usage_key)
 
-        self.assertEqual(result, "TestOrg__TestLibrary__test_problem")
+        self.assertEqual(result, "TestOrg__TestLibrary__test_problem_a63e2785")
 
     def test_migrate_node_wiki_tag(self):
         """


### PR DESCRIPTION
## Description

This PR addresses several previously noted TODOs in the `migrate_from_modulestore` task logic and improves testing accuracy and coverage.

### Key Changes

- Implemented incremental creation of `ModulestoreBlockSource` and `ModulestoreBlockMigration` records during migration.
- Updated logic to resolve `target_id`s for collection population based on created migration records.
- Refactored slug generation for block keys to avoid collisions and ensure compatibility.
- Improved error handling when creating component version content to gracefully handle duplicates.
- Cleaned up obsolete inline comments and removed unnecessary legacy code paths.
- Updated test expectations for `slugify_source_usage_key()` to reflect hashed values.
- Fixed failing test for `migrate_from_modulestore_success_course` to use assertions properly.